### PR TITLE
Add requester B2B

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Initialize the SDK by calling `africastalking.initialize(username, api_key)`. Af
       - `destinationChannel`: Name or number of the channel that will receive payment by the provider. `REQUIRED`
       - `destinationAccount`: Name used by the business to receive money on the provided destinationChannel. `REQUIRED`
       - `amount`: Amount to pay. `REQUIRED`
+      - `requester`: PhoneNumber through which KPLC will send tokens when using B2B to buy electricity tokens.
       - `metadata`: Additional data to associate with the transaction. `REQUIRED`
 
 - `mobile_data(product_name: str, recipients: dict)`: Send mobile data to customers.

--- a/africastalking/Payment.py
+++ b/africastalking/Payment.py
@@ -125,12 +125,12 @@ class PaymentService(Service):
                 'amount': And(lambda f: float(f) > 0),
                 'destinationChannel': And(str, len),
                 'destinationAccount': And(str, len),
+                Optional('requester'): And(str, lambda s: validate_phone(s)),
                 Optional('metadata'): And(dict)
             })
             business = schema.validate(business)
         except SchemaError as err:
             raise ValueError('Invalid business: ' + err.message)
-
         url = self._make_url('/mobile/b2b/request')
         headers = dict(self._headers)
         headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
We recently updated the B2B API to enable clients pay for tokens.

The new B2B API has a new field in the request body called requester which allows insertion of a phone number through which KPLC will send tokens.

```
{
  "username": "username",
  "productName": "productname",
  "provider" : "Mpesa",
  "transferType": "BusinessPaybill",
    "currencyCode": "KES",
       "amount": 100,
       "destinationChannel" : "888880", 
       "destinationAccount": "01450717531", 
       "requester":"2547XX...",
      "metadata": {
        "shopId": "1234",
        "itemId": "abcdef"
      }
}
```
