### PR TITLE
Improve error message semantics

### DIFF
--- a/africastalking/__init__.py
+++ b/africastalking/__init__.py
@@ -18,7 +18,10 @@ Insights = None
 
 def initialize(username, api_key):
     if username is None or api_key is None:
-        raise RuntimeError("Invalid username and/or api_key")
+        raise RuntimeError(
+            "Missing credentials: username and api_key are both required. \n"
+            "See: https://developers.africastalking.com/docs/authentication"
+        )
 
     globals()["SMS"] = SMSService(username, api_key)
     globals()["Airtime"] = AirtimeService(username, api_key)


### PR DESCRIPTION
## Description
This PR introduces a minor patch to enhance error message semantics.

```python
# Current impl.

def initialize(username, api_key):
    if username is None or api_key is None:
        raise RuntimeError("Invalid username and/or api_key")
```

Not only is the above message misleading, but it's also **logically** incorrect.
"Invalid" infers some form of malformed input or failed validation, which requires _existing_ data. Here, we only check if both `username` and `api_key` exist. This means we _raise_ on the fact of non-existent data, but proceed to tell the user the data is **invalid**.

### Patches

- Keep `RuntimeError` but update error message
- Add reference to official API docs for actionable insight to resolve the error