### PR TITLE
Add timeout to SMS and service, default 10s

### DIFF
--- a/africastalking/Airtime.py
+++ b/africastalking/Airtime.py
@@ -1,6 +1,7 @@
 import json
 from .Service import (
     APIService,
+    DEFAULT_TIMEOUT_S,
     validate_amount,
     validate_phone,
     validate_currency,
@@ -25,6 +26,7 @@ class AirtimeService(APIService):
         idempotency_key=None,
         callback=None,
         max_num_retry=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         def join_amount_and_currency(obj):
             obj["amount"] = " ".join([str(obj["currency_code"]), str(obj["amount"])])
@@ -95,4 +97,5 @@ class AirtimeService(APIService):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/Application.py
+++ b/africastalking/Application.py
@@ -1,4 +1,4 @@
-from .Service import APIService
+from .Service import APIService, DEFAULT_TIMEOUT_S
 
 
 class ApplicationService(APIService):
@@ -9,7 +9,7 @@ class ApplicationService(APIService):
         super(ApplicationService, self)._init_service()
         self._baseUrl = self._baseUrl + "/version1"
 
-    def fetch_application_data(self, callback=None):
+    def fetch_application_data(self, callback=None, timeout=DEFAULT_TIMEOUT_S):
         url = self._make_url("/user")
         params = {"username": self._username}
         return self._make_request(
@@ -19,4 +19,5 @@ class ApplicationService(APIService):
             params=params,
             data=None,
             callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/Insights.py
+++ b/africastalking/Insights.py
@@ -1,5 +1,5 @@
 import json
-from .Service import Service, validate_phone
+from .Service import DEFAULT_TIMEOUT_S, Service, validate_phone
 
 
 class InsightService(Service):
@@ -13,7 +13,9 @@ class InsightService(Service):
         else:
             self._baseUrl += self._PRODUCTION_DOMAIN + "/v1"
 
-    def check_sim_swap_state(self, phone_numbers, callback=None):
+    def check_sim_swap_state(
+        self, phone_numbers, callback=None, timeout=DEFAULT_TIMEOUT_S
+    ):
         url = self._make_url("/sim-swap")
         headers = dict(self._headers)
         headers["Content-Type"] = "application/json"
@@ -28,5 +30,11 @@ class InsightService(Service):
         }
         data = json.dumps(data)
         return self._make_request(
-            url, "POST", headers=headers, params=None, data=data, callback=callback
+            url,
+            "POST",
+            headers=headers,
+            params=None,
+            data=data,
+            callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/MobileData.py
+++ b/africastalking/MobileData.py
@@ -1,10 +1,11 @@
 import json
-from schema import Schema, And, Optional
+from schema import And, Optional, Schema
 from .Service import (
+    DEFAULT_TIMEOUT_S,
     Service,
-    validate_phone,
     validate_data_units,
     validate_data_validity,
+    validate_phone,
 )
 
 
@@ -19,7 +20,7 @@ class MobileDataService(Service):
         else:
             self._baseUrl += self._PRODUCTION_DOMAIN
 
-    def send(self, product_name, recipients, callback=None):
+    def send(self, product_name, recipients, callback=None, timeout=DEFAULT_TIMEOUT_S):
         schema = Schema(
             [
                 {
@@ -42,10 +43,18 @@ class MobileDataService(Service):
         }
         data = json.dumps(data)
         return self._make_request(
-            url, "POST", headers=headers, params=None, data=data, callback=callback
+            url,
+            "POST",
+            headers=headers,
+            params=None,
+            data=data,
+            callback=callback,
+            timeout=timeout,
         )
 
-    def find_transaction(self, transaction_id, callback=None):
+    def find_transaction(
+        self, transaction_id, callback=None, timeout=DEFAULT_TIMEOUT_S
+    ):
         url = self._make_url("/query/transaction/find")
         headers = dict(self._headers)
         headers["Content-Type"] = "application/json"
@@ -54,10 +63,16 @@ class MobileDataService(Service):
             "transactionId": transaction_id,
         }
         return self._make_request(
-            url, "GET", headers=headers, data=None, params=params, callback=callback
+            url,
+            "GET",
+            headers=headers,
+            data=None,
+            params=params,
+            callback=callback,
+            timeout=timeout,
         )
 
-    def fetch_wallet_balance(self, callback=None):
+    def fetch_wallet_balance(self, callback=None, timeout=DEFAULT_TIMEOUT_S):
         url = self._make_url("/query/wallet/balance")
         params = {
             "username": self._username,
@@ -69,4 +84,5 @@ class MobileDataService(Service):
             headers=self._headers,
             params=params,
             callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/SMS.py
+++ b/africastalking/SMS.py
@@ -1,6 +1,8 @@
 from .Service import APIService, validate_phone
 from schema import Schema, And, Optional, SchemaError
 
+DEFAULT_TIMEOUT_S = 10  # seconds
+
 
 class SMSService(APIService):
     def __init__(self, username, api_key):
@@ -12,7 +14,15 @@ class SMSService(APIService):
         if self._contentUrl:
             self._contentUrl = self._contentUrl + "/version1"
 
-    def send(self, message, recipients, sender_id=None, enqueue=False, callback=None):
+    def send(
+        self,
+        message,
+        recipients,
+        sender_id=None,
+        enqueue=False,
+        callback=None,
+        timeout=DEFAULT_TIMEOUT_S,
+    ):
         for phone in recipients:
             if not validate_phone(phone):
                 raise ValueError("Invalid phone number: " + phone)
@@ -38,6 +48,7 @@ class SMSService(APIService):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )
 
     def send_premium(
@@ -49,6 +60,7 @@ class SMSService(APIService):
         link_id=None,
         retry_duration_in_hours=None,
         callback=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         for phone in recipients:
             if not validate_phone(phone):
@@ -79,9 +91,12 @@ class SMSService(APIService):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )
 
-    def fetch_messages(self, last_received_id=None, callback=None):
+    def fetch_messages(
+        self, last_received_id=None, callback=None, timeout=DEFAULT_TIMEOUT_S
+    ):
         url = self._make_url("/messaging")
         params = {"username": self._username}
 
@@ -95,6 +110,7 @@ class SMSService(APIService):
             params=params,
             data=None,
             callback=callback,
+            timeout=timeout,
         )
 
     def create_safaricom_subscription(
@@ -107,6 +123,7 @@ class SMSService(APIService):
         source_ip=None,
         user_agent=None,
         callback=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         try:
             data = {
@@ -152,10 +169,17 @@ class SMSService(APIService):
             data=data,
             params=None,
             callback=callback,
+            timeout=timeout,
         )
 
     def send_hashed(
-        self, message, masked_number, sender_id, telco="Safaricom", callback=None
+        self,
+        message,
+        masked_number,
+        sender_id,
+        telco="Safaricom",
+        callback=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         url = self._make_url("/messaging/bulk")
         data = {
@@ -174,4 +198,5 @@ class SMSService(APIService):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/SMS.py
+++ b/africastalking/SMS.py
@@ -1,7 +1,5 @@
-from .Service import APIService, validate_phone
+from .Service import APIService, DEFAULT_TIMEOUT_S, validate_phone
 from schema import Schema, And, Optional, SchemaError
-
-DEFAULT_TIMEOUT_S = 10  # seconds
 
 
 class SMSService(APIService):

--- a/africastalking/Service.py
+++ b/africastalking/Service.py
@@ -80,8 +80,14 @@ class Service(object):
         raise NotImplementedError
 
     @staticmethod
-    def __make_get_request(url, headers, data, params, callback=None):
-        res = requests.get(url=url, headers=headers, params=params, data=data)
+    def __make_get_request(url, headers, data, params, callback=None, timeout=None):
+        res = requests.get(
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+            timeout=timeout,
+        )
 
         if callback is None or callback == {}:
             return res
@@ -89,19 +95,29 @@ class Service(object):
             callback(res)
 
     @staticmethod
-    def __make_post_request(url, headers, data, params, callback=None):
+    def __make_post_request(url, headers, data, params, callback=None, timeout=None):
         res = requests.post(
             url=url,
             headers=headers,
             params=params,
             data=data,
+            timeout=timeout,
         )
         if callback is None or callback == {}:
             return res
         else:
             callback(res)
 
-    def _make_request(self, url, method, headers, data, params, callback=None):
+    def _make_request(
+        self,
+        url,
+        method,
+        headers,
+        data,
+        params,
+        callback=None,
+        timeout=None,
+    ):
         method = method.upper()
         if callback is None:
             if method == "GET":
@@ -110,6 +126,7 @@ class Service(object):
                     headers=headers,
                     data=data,
                     params=params,
+                    timeout=timeout,
                 )
             elif method == "POST":
                 res = self.__make_post_request(
@@ -117,6 +134,7 @@ class Service(object):
                     headers=headers,
                     data=data,
                     params=params,
+                    timeout=timeout,
                 )
             else:
                 raise AfricasTalkingException("Unexpected HTTP method: " + method)
@@ -149,7 +167,7 @@ class Service(object):
                 raise AfricasTalkingException("Unexpected HTTP method: " + method)
 
             thread = threading.Thread(
-                target=_target, args=(url, headers, data, params, cb)
+                target=_target, args=(url, headers, data, params, cb, timeout)
             )
             thread.start()
             return thread

--- a/africastalking/Service.py
+++ b/africastalking/Service.py
@@ -2,6 +2,11 @@ import re
 import threading
 import requests
 
+# Default timeout for all requests (connect timeout, read timeout)
+# Set to slightly higher than a multiple of 3
+# See https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+DEFAULT_TIMEOUT_S = (3.05, 9.05)
+
 
 def validate_currency(currency_str):
     return len(currency_str) == 3
@@ -80,7 +85,9 @@ class Service(object):
         raise NotImplementedError
 
     @staticmethod
-    def __make_get_request(url, headers, data, params, callback=None, timeout=None):
+    def __make_get_request(
+        url, headers, data, params, callback=None, timeout=DEFAULT_TIMEOUT_S
+    ):
         res = requests.get(
             url=url,
             headers=headers,
@@ -95,7 +102,9 @@ class Service(object):
             callback(res)
 
     @staticmethod
-    def __make_post_request(url, headers, data, params, callback=None, timeout=None):
+    def __make_post_request(
+        url, headers, data, params, callback=None, timeout=DEFAULT_TIMEOUT_S
+    ):
         res = requests.post(
             url=url,
             headers=headers,
@@ -116,7 +125,7 @@ class Service(object):
         data,
         params,
         callback=None,
-        timeout=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         method = method.upper()
         if callback is None:

--- a/africastalking/Token.py
+++ b/africastalking/Token.py
@@ -1,18 +1,23 @@
 import json
-
-from .Service import APIService
+from .Service import DEFAULT_TIMEOUT_S, APIService
 
 
 class TokenService(APIService):
     def __init__(self, username, api_key):
         super(TokenService, self).__init__(username, api_key)
 
-    def generate_auth_token(self, callback=None):
+    def generate_auth_token(self, callback=None, timeout=DEFAULT_TIMEOUT_S):
         url = self._make_url("/auth-token/generate")
         headers = dict(self._headers)
         headers["Content-Type"] = "application/json"
         data = json.dumps({"username": self._username})
 
         return self._make_request(
-            url, "POST", headers, params=None, data=data, callback=callback
+            url,
+            "POST",
+            headers,
+            params=None,
+            data=data,
+            callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/Voice.py
+++ b/africastalking/Voice.py
@@ -1,4 +1,4 @@
-from .Service import Service, validate_phone
+from .Service import DEFAULT_TIMEOUT_S, Service, validate_phone
 
 
 class VoiceService(Service):
@@ -12,7 +12,7 @@ class VoiceService(Service):
         else:
             self._baseUrl += self._PRODUCTION_DOMAIN
 
-    def call(self, callFrom, callTo, callback=None):
+    def call(self, callFrom, callTo, callback=None, timeout=DEFAULT_TIMEOUT_S):
         for phone_number in callTo:
             if not validate_phone(phone_number):
                 raise ValueError("Invalid callTo phone number:" + phone_number)
@@ -33,9 +33,12 @@ class VoiceService(Service):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )
 
-    def fetch_queued_calls(self, phone_number, callback=None):
+    def fetch_queued_calls(
+        self, phone_number, callback=None, timeout=DEFAULT_TIMEOUT_S
+    ):
         if not validate_phone(phone_number):
             raise ValueError("Invalid phone number")
 
@@ -51,9 +54,10 @@ class VoiceService(Service):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )
 
-    def media_upload(self, phone_number, url, callback=None):
+    def media_upload(self, phone_number, url, callback=None, timeout=DEFAULT_TIMEOUT_S):
         if not validate_phone(phone_number):
             raise ValueError("Invalid phone number")
 
@@ -70,4 +74,5 @@ class VoiceService(Service):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )

--- a/africastalking/Whatsapp.py
+++ b/africastalking/Whatsapp.py
@@ -1,8 +1,7 @@
 import json
 import warnings
-from .Service import Service, validate_phone
-from schema import Schema, And, Optional, SchemaError
-
+from schema import And, Optional, Schema, SchemaError
+from .Service import DEFAULT_TIMEOUT_S, Service, validate_phone
 
 media_types = {
     "Image": "Image",
@@ -42,6 +41,7 @@ class WhatsappService(Service):
         wa_number,
         phone_number,
         callback=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         try:
             data = {
@@ -106,6 +106,7 @@ class WhatsappService(Service):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )
 
     def send_template(
@@ -116,6 +117,7 @@ class WhatsappService(Service):
         language,
         category,
         callback=None,
+        timeout=DEFAULT_TIMEOUT_S,
     ):
         try:
             data = {
@@ -187,4 +189,5 @@ class WhatsappService(Service):
             params=None,
             data=data,
             callback=callback,
+            timeout=timeout,
         )

--- a/test/test_sms.py
+++ b/test/test_sms.py
@@ -50,6 +50,13 @@ class TestSmsService(unittest.TestCase):
                 }
             },
             status=200,
+            match=[
+                responses.matchers.request_kwargs_matcher(
+                    {
+                        "timeout": 10,
+                    }
+                )
+            ],
         )
         res = service.send(
             "test_send()",
@@ -86,6 +93,13 @@ class TestSmsService(unittest.TestCase):
                 }
             },
             status=200,
+            match=[
+                responses.matchers.request_kwargs_matcher(
+                    {
+                        "timeout": 10,
+                    }
+                )
+            ],
         )
 
         def on_finish(error, data):
@@ -129,6 +143,13 @@ class TestSmsService(unittest.TestCase):
                 }
             },
             status=200,
+            match=[
+                responses.matchers.request_kwargs_matcher(
+                    {
+                        "timeout": 10,
+                    }
+                )
+            ],
         )
         res = service.send_premium(
             "test_send_premium()",
@@ -162,6 +183,13 @@ class TestSmsService(unittest.TestCase):
                 }
             },
             status=200,
+            match=[
+                responses.matchers.request_kwargs_matcher(
+                    {
+                        "timeout": 10,
+                    }
+                )
+            ],
         )
         res = service.fetch_messages(0)
         assert len(res) >= 0
@@ -178,6 +206,13 @@ class TestSmsService(unittest.TestCase):
                 "url": "https://dcbatf2.safaricom.co.ke/v2/service/safaricom/bluu/Tid_177539048695398400?onError=https%3A%2F%2Fmidge-driven-flamingo.ngrok-free.app%2Fcontent%2Fpremium%2Fevina%2Fsubscription%3Ftype%3DERR%26rId%3DrequestId-9168bb62-3b6a-4a87-811d-4ef4c7e1e6dd",
             },
             status=200,
+            match=[
+                responses.matchers.request_kwargs_matcher(
+                    {
+                        "timeout": 10,
+                    }
+                )
+            ],
         )
         res = service.create_safaricom_subscription(
             short_code="78942",

--- a/test/test_sms.py
+++ b/test/test_sms.py
@@ -15,6 +15,7 @@ createSubscription(shortCode: String, keyword: String, phoneNumber: String): Cre
 import africastalking
 import unittest
 import responses
+from africastalking.Service import DEFAULT_TIMEOUT_S
 from test import USERNAME, API_KEY
 
 africastalking.initialize(USERNAME, API_KEY)
@@ -53,7 +54,7 @@ class TestSmsService(unittest.TestCase):
             match=[
                 responses.matchers.request_kwargs_matcher(
                     {
-                        "timeout": 10,
+                        "timeout": DEFAULT_TIMEOUT_S,
                     }
                 )
             ],
@@ -96,7 +97,7 @@ class TestSmsService(unittest.TestCase):
             match=[
                 responses.matchers.request_kwargs_matcher(
                     {
-                        "timeout": 10,
+                        "timeout": DEFAULT_TIMEOUT_S,
                     }
                 )
             ],
@@ -146,7 +147,7 @@ class TestSmsService(unittest.TestCase):
             match=[
                 responses.matchers.request_kwargs_matcher(
                     {
-                        "timeout": 10,
+                        "timeout": DEFAULT_TIMEOUT_S,
                     }
                 )
             ],
@@ -186,7 +187,7 @@ class TestSmsService(unittest.TestCase):
             match=[
                 responses.matchers.request_kwargs_matcher(
                     {
-                        "timeout": 10,
+                        "timeout": DEFAULT_TIMEOUT_S,
                     }
                 )
             ],
@@ -209,7 +210,7 @@ class TestSmsService(unittest.TestCase):
             match=[
                 responses.matchers.request_kwargs_matcher(
                     {
-                        "timeout": 10,
+                        "timeout": DEFAULT_TIMEOUT_S,
                     }
                 )
             ],


### PR DESCRIPTION
As suggested in the [requests docs](https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts), it's best practice in requests to add a timeout to all requests. By default calls will hang indefinitely until killed. Historically when using the AfricasTalking API we've seen timeouts after 60s, which is an extremely long time to block on a worker thread.

This PR, like in #53, adds a 9s default timeout (defined in `Service` and propagated to all services). It additionally makes the API configurable so that users can pass in their own timeouts:

```py
sms.send(message, recipients, sender_id, timeout=5)
```

The unit tests were updated to use the responses matcher to check for the timeout kwargs.